### PR TITLE
fix startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -109,7 +109,7 @@ class FacBot(commands.Bot):
     async def send_to_factorio(self, ctx):
         msg = "{}: {}".format(ctx.author.display_name, ctx.message.content)
         logger.debug("Msg from discord: \"{}\"".format(msg))
-        with MCRcon(self.pw, self.pw, 27015) as rcon:
+        with MCRcon(self.host, self.pw, 27015) as rcon:
             resp = rcon.command(msg)
             logger.debug("Response from factorio: '%s'", resp)
 

--- a/main.py
+++ b/main.py
@@ -48,6 +48,12 @@ class FacLogHandler(PatternMatchingEventHandler):
         for line in self.logfile:
             pass
 
+    def on_created(self, event):
+        # Factorio moves the file aside and creates a new one.
+        # Close the existing file and look for the new one.
+        self.logfile.close()
+        self.spin_up()
+
     def on_modified(self, event):
         # When a line is written to the log, handle any action needed.
         # Right now, there's only chat.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 watchdog==0.9.0
-discord.py==1.1.1
+discord.py==1.4.1
 mcrcon==0.5.2


### PR DESCRIPTION
- Update discord.py to fix problems connecting to Discord: https://github.com/Rapptz/discord.py/issues/5109
- Fix an error where the password is used both as the password and as the name of the host.
- Reopen the log file when Factorio recreates it to handle a race condition where facbridge finds the log before Factorio has started and then cannot read any chat.